### PR TITLE
Log more details on connection failures

### DIFF
--- a/lib/poseidon/connection.rb
+++ b/lib/poseidon/connection.rb
@@ -51,7 +51,7 @@ module Poseidon
       req = ProduceRequest.new( request_common(:produce),
                                 required_acks,
                                 timeout,
-                                messages_for_topics) 
+                                messages_for_topics)
       send_request(req)
       if required_acks != 0
         read_response(ProduceResponse)
@@ -71,7 +71,7 @@ module Poseidon
                                 REPLICA_ID,
                                 max_wait_time,
                                 min_bytes,
-                                topic_fetches) 
+                                topic_fetches)
       send_request(req)
       read_response(FetchResponse)
     end

--- a/lib/poseidon/connection.rb
+++ b/lib/poseidon/connection.rb
@@ -163,7 +163,7 @@ module Poseidon
     end
 
     def raise_connection_failed_from_exception(ex)
-      raise_connection_failed_error("Inital exception class=#{ex.class} message=#{ex.message}")
+      raise_connection_failed_error("Initial exception class=#{ex.class} message=#{ex.message}")
     end
 
     def raise_connection_failed_error(message)

--- a/lib/poseidon/sync_producer.rb
+++ b/lib/poseidon/sync_producer.rb
@@ -155,8 +155,8 @@ module Poseidon
       else
         messages_for_broker.successfully_sent(response)
       end
-    rescue Connection::ConnectionFailedError
-      Poseidon.logger.warn { "Failed to send messages to #{messages_for_broker.broker_id} due to connection failure"  }
+    rescue Connection::ConnectionFailedError => ex
+      Poseidon.logger.warn { "Failed to send messages to #{messages_for_broker.broker_id} due to connection failure: message=#{ex.message}" }
       false
     end
   end


### PR DESCRIPTION
The `ConnectionFailedError` is effectively a wrapper around several kinds
of underlying errors, and we'd like to get more details logged about the
initial cause of such errors.

This changes the generation of the `ConnectionFailedError` to include
initial exception details when relevant, and changes the capturing code in
the producer to also log some of those details.

cc @codeclimate/review
