### PR TITLE
Rescue Errno::ETIMEDOUT to ConnectionFailure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.3.1-alpine
 MAINTAINER Code Climate <hello@codeclimate.com>
 
-RUN apk --update add git build-base autoconf automake libtool ruby-dev ruby-bundler snappy openjdk8 && \
+RUN apk --update add curl git build-base autoconf automake libtool ruby-dev ruby-bundler snappy openjdk8 && \
   rm -fr /usr/share/ri
 
 ENV KAFKA_SRC=http://apache.cs.utah.edu/kafka/0.8.2.1/kafka_2.10-0.8.2.1.tgz

--- a/lib/poseidon/connection.rb
+++ b/lib/poseidon/connection.rb
@@ -135,7 +135,7 @@ module Poseidon
       buffer = Protocol::RequestBuffer.new
       request.write(buffer)
       ensure_write_or_timeout([buffer.to_s.bytesize].pack("N") + buffer.to_s)
-    rescue Errno::EPIPE, Errno::ECONNRESET, TimeoutException => ex
+    rescue Errno::EPIPE, Errno::ECONNRESET, Errno::ETIMEDOUT, TimeoutException => ex
       @socket = nil
       raise_connection_failed_from_exception(ex)
     end


### PR DESCRIPTION
I believe this is the intended behavior of the code: to handle a timeout as a
connection failure which will bubble up into the Producer's retry semantics.

I believe the code didn't realize that IO.select may return true but the actual
Socker#write may still fail with a timeout, so it wasn't being handled. This
meant it would bubble out as a full exception without any retry handling. We
see this at a low rate on 0.8, but a higher rate on 0.10.

This change makes the smaller fix of adding this exception to the rescue list,
instead of the potential larger fix of removing the select and manual
TimeoutException entirely and just relying on this exception to indicate a
timeout. Making that larger fix would require leaning on the above assumptions
more than I'm comfortable with.

/cc @codeclimate/review
