### PR TITLE
Raise meaningful error, address spec warnings

### DIFF
--- a/lib/poseidon.rb
+++ b/lib/poseidon.rb
@@ -62,6 +62,9 @@ module Poseidon
       10 => MessageSizeTooLarge
     }
 
+    # Raised when messages were not successfully produced to Kafka
+    class MessageDeliveryError < StandardError; end
+
     # Raised when a custom partitioner tries to send
     # a message to a partition that doesn't exist.
     class InvalidPartitionError < StandardError; end

--- a/lib/poseidon/sync_producer.rb
+++ b/lib/poseidon/sync_producer.rb
@@ -65,7 +65,7 @@ module Poseidon
       end
 
       if messages_to_send.pending_messages?
-        raise "Failed to send all messages: #{messages_to_send.messages} remaining"
+        raise Errors::MessageDeliveryError, "Failed to send all messages: #{messages_to_send.messages} remaining"
       else
         true
       end

--- a/spec/unit/producer_spec.rb
+++ b/spec/unit/producer_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Producer do
   it "requires brokers and client_id" do
-    expect { Producer.new }.to raise_error
+    expect { Producer.new }.to raise_error(ArgumentError)
   end
 
   it "raises ArgumentError on unknown arguments" do

--- a/spec/unit/protocol_spec.rb
+++ b/spec/unit/protocol_spec.rb
@@ -49,6 +49,6 @@ RSpec.describe "objects with errors" do
                                                   [partition_fetch_response])
     response = FetchResponse.new(double('common'), [topic_fetch_response])
 
-    expect { response.raise_error_if_one_exists }.to raise_error
+    expect { response.raise_error_if_one_exists }.to raise_error(Poseidon::Errors::LeaderNotAvailable)
   end
 end

--- a/spec/unit/sync_producer_spec.rb
+++ b/spec/unit/sync_producer_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe SyncProducer do
       it "raises an exception" do
         expect {
           @sp.send_messages([Message.new(:topic => "topic", :value => "value")])
-        }.to raise_error
+        }.to raise_error(Poseidon::Errors::MessageDeliveryError)
       end
     end
 


### PR DESCRIPTION
- Don't raise a bare RuntimeError on message delivery
- Asset against specific error classes in specs

/cc @codeclimate/review
