### PR TITLE
Raise error when asking for the leader of an unknown topic

### DIFF
--- a/lib/poseidon/cluster_metadata.rb
+++ b/lib/poseidon/cluster_metadata.rb
@@ -49,6 +49,8 @@ module Poseidon
 
     # Return lead broker for topic and partition
     def lead_broker_for_partition(topic_name, partition)
+      raise ::Poseidon::Errors::UnknownTopicOrPartition unless @topic_metadata[topic_name]
+
       broker_id = @topic_metadata[topic_name].partition_leader(partition)
       if broker_id
         @brokers[broker_id]

--- a/spec/unit/cluster_metadata_spec.rb
+++ b/spec/unit/cluster_metadata_spec.rb
@@ -42,5 +42,11 @@ RSpec.describe ClusterMetadata do
       expect(@cm.lead_broker_for_partition("test",1).id).to eq(1)
       expect(@cm.lead_broker_for_partition("test",2).id).to eq(2)
     end
+
+    it "raises an UnknownErrorOrPartition when the topic does not exist" do
+      expect {
+        @cm.lead_broker_for_partition("nonsense",1)
+      }.to raise_error(::Poseidon::Errors::UnknownTopicOrPartition)
+    end
   end
 end


### PR DESCRIPTION
## Expected Behavior
Attempting to fetch from an undefined topic raises a `Poseidon::Errors::UnknownTopicOrPartition` error.

## Actual Behavior
A `NoMethodError` is raised.
```
poseidon/cluster_metadata.rb:52:in `lead_broker_for_partition': undefined method `partition_leader' for nil:NilClass (NoMethodError)
```

The proposed change raises a more specific error which a client can choose to catch and handle.
The use case in mind with this change is an environment allowing Kafka to auto-create topics.
Before the fix, clients would receive a `NoMethodError` when attempting to fetch from a topic that has yet to be created.
With this change applied the client receives an `UnknownTopicOrPartition` error which can be more elegantly handled.