### PR TITLE
Raise helpful error for unknown partition

### DIFF
--- a/lib/poseidon/cluster_metadata.rb
+++ b/lib/poseidon/cluster_metadata.rb
@@ -55,7 +55,7 @@ module Poseidon
       if broker_id
         @brokers[broker_id]
       else
-        nil
+        raise ::Poseidon::Errors::UnknownTopicOrPartition
       end
     end
 

--- a/spec/integration/multiple_brokers/consumer_spec.rb
+++ b/spec/integration/multiple_brokers/consumer_spec.rb
@@ -23,6 +23,21 @@ RSpec.describe "consuming with multiple brokers", :type => :request do
     expect(brokers.size).to eq(3)
   end
 
+  it "raises a helpful error when there's no matching broker to be found" do
+    pc = PartitionConsumer.consumer_for_partition("test_client",
+                                                  ["localhost:9092"],
+                                                  "test", 0,
+                                                  :earliest_offset)
+    expect(pc).to be_a PartitionConsumer
+
+    expect {
+      PartitionConsumer.consumer_for_partition("test_client",
+                                               ["localhost:9092"],
+                                               "test", 42,
+                                               :earliest_offset)
+    }.to raise_error(::Poseidon::Errors::UnknownTopicOrPartition)
+  end
+
   it "consumes from all partitions" do
     @p = Producer.new(["localhost:9092","localhost:9093","localhost:9094"], "test",
                      :required_acks => 1)

--- a/spec/integration/multiple_brokers/consumer_spec.rb
+++ b/spec/integration/multiple_brokers/consumer_spec.rb
@@ -24,18 +24,17 @@ RSpec.describe "consuming with multiple brokers", :type => :request do
   end
 
   it "raises a helpful error when there's no matching broker to be found" do
-    pc = PartitionConsumer.consumer_for_partition("test_client",
-                                                  ["localhost:9092"],
-                                                  "test", 0,
-                                                  :earliest_offset)
-    expect(pc).to be_a PartitionConsumer
+    get_consumer = ->(partition) {
+      PartitionConsumer.consumer_for_partition(
+        "test_client",
+        ["localhost:9092"],
+        "test", partition,
+        :earliest_offset,
+      )
+    }
 
-    expect {
-      PartitionConsumer.consumer_for_partition("test_client",
-                                               ["localhost:9092"],
-                                               "test", 42,
-                                               :earliest_offset)
-    }.to raise_error(::Poseidon::Errors::UnknownTopicOrPartition)
+    expect(get_consumer.(0)).to be_a PartitionConsumer
+    expect { get_consumer.(42) }.to raise_error(::Poseidon::Errors::UnknownTopicOrPartition)
   end
 
   it "consumes from all partitions" do


### PR DESCRIPTION
The idea is that we want to be able to call
Poseidon::PartitionConsumer.consumer_for_partition with a partition that
doesn't exist, but will soon. We can write our services to be tolerant
of this exception and keep retrying until they get back a broker.